### PR TITLE
Fix sample contract packaging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,11 @@ on:
         description: 'A path containing a Dockerfile passed from the caller workflow'
         required: true
         type: string
+      chaincode:
+        description: 'A boolean indicating whether to create a chaincode package passed from the caller workflow'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -32,6 +37,7 @@ jobs:
         DOCKER_BUILD_PATH: ${{ inputs.path }}
         IMAGE_NAME: ${{ inputs.imagename }}
     - name: Publish Docker image
+      id: publish_image
       if: github.event_name != 'pull_request'
       run: |
         echo ${DOCKER_PW} | docker login ghcr.io -u ${DOCKER_USER} --password-stdin
@@ -47,7 +53,7 @@ jobs:
         DOCKER_PW: ${{ secrets.GITHUB_TOKEN }}
 
   package:
-    if: needs.build.outputs.image_digest != ''
+    if: inputs.chaincode && needs.build.outputs.image_digest != ''
     needs: build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/go-contract-image.yml
+++ b/.github/workflows/go-contract-image.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       imagename: go-contract
       path: samples/go-contract
+      chaincode: true

--- a/.github/workflows/java-contract-image.yml
+++ b/.github/workflows/java-contract-image.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       imagename: java-contract
       path: samples/java-contract
+      chaincode: true

--- a/.github/workflows/node-contract-image.yml
+++ b/.github/workflows/node-contract-image.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       imagename: node-contract
       path: samples/node-contract
+      chaincode: true


### PR DESCRIPTION
Sample contracts should be packaged for the k8s builder, but not the k8s builder image itself

Signed-off-by: James Taylor <jamest@uk.ibm.com>