### PR TITLE
Improve logging

### DIFF
--- a/cmd/detect/main.go
+++ b/cmd/detect/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/hyperledger-labs/fabric-builder-k8s/internal/builder"
@@ -39,7 +40,11 @@ func main() {
 	}
 
 	if err := detect.Run(ctx); err != nil {
-		logger.Printf("Error detecting chaincode: %+v", err)
+		if !errors.Is(err, builder.ErrUnsupportedChaincodeType) {
+			// don't spam the peer log if it's just chaincode we don't recognise
+			logger.Printf("Error detecting chaincode: %+v", err)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/cmd/detect/main_test.go
+++ b/cmd/detect/main_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 )
 
@@ -30,4 +31,20 @@ var _ = Describe("Main", func() {
 			"UNEXPECTED_ARGUMENT",
 		),
 	)
+
+	It("Logs the label when a supported chaincode is detected", func() {
+		command := exec.Command(detectCmdPath, "CHAINCODE_SOURCE_DIR", "./testdata/validtype")
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session.Err).Should(gbytes.Say(`detect \[\d+\]: Detected k8s chaincode: basic`))
+	})
+
+	It("Does not log an error when an unsupported chaincode is detected", func() {
+		command := exec.Command(detectCmdPath, "CHAINCODE_SOURCE_DIR", "./testdata/invalidtype")
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session.Err).ShouldNot(gbytes.Say(`detect \[\d+\]:`))
+	})
 })

--- a/cmd/run/main_test.go
+++ b/cmd/run/main_test.go
@@ -1,0 +1,29 @@
+package main_test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Main", func() {
+	DescribeTable("Running the run command produces the correct error code",
+		func(expectedErrorCode int, args ...string) {
+			command := exec.Command(runCmdPath, args...)
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(expectedErrorCode))
+		},
+		Entry("When too few arguments are provided", 1, "BUILD_OUTPUT_DIR"),
+		Entry(
+			"When too many arguments are provided",
+			1,
+			"BUILD_OUTPUT_DIR",
+			"RUN_METADATA_DIR",
+			"UNEXPECTED_ARGUMENT",
+		),
+	)
+})

--- a/cmd/run/run_suite_test.go
+++ b/cmd/run/run_suite_test.go
@@ -1,0 +1,27 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+//nolint:gochecknoglobals // not sure how to avoid this
+var runCmdPath string
+
+func TestRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Run Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	runCmdPath, err = gexec.Build("github.com/hyperledger-labs/fabric-builder-k8s/cmd/run")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/internal/builder/detect.go
+++ b/internal/builder/detect.go
@@ -5,6 +5,7 @@ package builder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -19,8 +20,11 @@ type Detect struct {
 }
 
 type metadata struct {
-	Type string `json:"type"`
+	Label string `json:"label"`
+	Type  string `json:"type"`
 }
+
+var ErrUnsupportedChaincodeType = errors.New("chaincode type not supported")
 
 func (d *Detect) Run(ctx context.Context) error {
 	logger := log.New(ctx)
@@ -41,8 +45,12 @@ func (d *Detect) Run(ctx context.Context) error {
 	}
 
 	if strings.ToLower(metadata.Type) == "k8s" {
+		logger.Printf("Detected k8s chaincode: %s", metadata.Label)
+
 		return nil
 	}
 
-	return fmt.Errorf("chaincode type not supported: %s", metadata.Type)
+	logger.Debugf("Chaincode type not supported: %s", metadata.Type)
+
+	return ErrUnsupportedChaincodeType
 }

--- a/internal/builder/run.go
+++ b/internal/builder/run.go
@@ -51,5 +51,7 @@ func (r *Run) Run(ctx context.Context) error {
 		return err
 	}
 
+	logger.Printf("Running chaincode ID %s in kubernetes pod %s/%s", chaincodeData.ChaincodeID, pod.Namespace, pod.Name)
+
 	return util.WaitForChaincodePod(ctx, logger, podsClient, pod, chaincodeData.ChaincodeID)
 }


### PR DESCRIPTION
- always log the chaincode pod details in the run phase
- avoid spamming peer log for unsupported chaincode in the detect phase

Signed-off-by: James Taylor <jamest@uk.ibm.com>