### PR TITLE
Fix GHA node deprecation warning

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -76,8 +76,10 @@ jobs:
         CHAINCODE_LABEL: ${{ inputs.chaincode-label }}
         CHAINCODE_VERSION: ${{ github.ref_name }}
 
-    - name: Release package
+    - name: Upload package
+      run: gh release upload $GITHUB_REF_NAME {CHAINCODE_LABEL}-${CHAINCODE_VERSION}.tgz
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ inputs.chaincode-label }}-${{ github.ref_name }}.tgz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CHAINCODE_LABEL: ${{ inputs.chaincode-label }}
+        CHAINCODE_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,13 +56,13 @@ jobs:
         ls -l fabric-builder-k8s-${GOOS}-${GOARCH}.tgz
 
     - name: Rename package
-      if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         export GOOS=$(go env GOOS)
         mv fabric-builder-k8s-${GOOS}-${GOARCH}.tgz fabric-builder-k8s-${GITHUB_REF_NAME}-${GOOS}-${GOARCH}.tgz
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: fabric-builder-k8s-*.tgz
+    - name: Upload package
+      run: gh release upload $GITHUB_REF_NAME fabric-builder-k8s-${GITHUB_REF_NAME}-${GOOS}-${GOARCH}.tgz
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use GitHub cli to upload assets to release instead of the softprops/action-gh-release action

Signed-off-by: James Taylor <jamest@uk.ibm.com>