### PR TITLE
Fix chaincode package uploads

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Create package
       uses: hyperledgendary/package-k8s-chaincode-action@ba10aea43e3d4f7991116527faf96e3c2b07abc7
       with:


### PR DESCRIPTION
Add checkout step- the gh cli needs to be run in a git repository

Signed-off-by: James Taylor <jamest@uk.ibm.com>