### PR TITLE
Fix k8s object names

### DIFF
--- a/cmd/run/main_test.go
+++ b/cmd/run/main_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Main", func() {
 			).Should(gbytes.Say(`run \[\d+\] DEBUG: FABRIC_K8S_BUILDER_SERVICE_ACCOUNT=chaincode`))
 			Eventually(
 				session.Err,
-			).Should(gbytes.Say(`run \[\d+\]: Running chaincode ID CHAINCODE_ID in kubernetes pod chaincode/cc-mspid-core-peer-id-abcdefghijklmnopqrstuvwxyz-0123456789chai`))
+			).Should(gbytes.Say(`run \[\d+\]: Running chaincode ID CHAINCODE_ID in kubernetes pod chaincode/cc-m4eml38l6lv2ost7v1i3q6698a5p4gu1l3lnflb4boi7jnle6lt0`))
 
 			pipe := script.Exec(
 				"kubectl wait --for=condition=ready pod --timeout=120s --namespace=chaincode -l fabric-builder-k8s-peerid=core-peer-id-abcdefghijklmnopqrstuvwxyz-0123456789",

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -1,0 +1,42 @@
+package util_test
+
+import (
+	"github.com/hyperledger-labs/fabric-builder-k8s/internal/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("K8s", func() {
+	Describe("GetValidName", func() {
+		It("should return a string with a maximum of 63 characters", func() {
+			name := util.GetValidName("CongaCongaCongaCongaCongaCongaCongaCongaCongaCongaCongaCongaOrgMsp", "CongaCongaCongaCongaCongaCongaCongaCongaCongaCongaCongaCongaOrgPeer0", "fabfabfabfabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(len(name)).To(BeNumerically("<=", 63))
+		})
+
+		It("should return a string which starts with an alphabetic character", func() {
+			name := util.GetValidName("GreenCongaOrg", "GreenCongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(name).To(MatchRegexp("^[a-z]"))
+		})
+
+		It("should return a string which ends with an alphanumeric character", func() {
+			name := util.GetValidName("BlueCongaOrg", "BlueCongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(name).To(MatchRegexp("[a-z0-9]$"))
+		})
+
+		It("should return a string which only contains lowercase alphanumeric characters or '-'", func() {
+			name := util.GetValidName("BlueCongaOrg", "BlueCongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(name).To(MatchRegexp("^(?:[a-z0-9]|-)+$"))
+		})
+
+		It("should return different names for different input", func() {
+			name1 := util.GetValidName("GreenCongaOrg", "GreenCongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			name2 := util.GetValidName("BlueCongaOrg", "BlueCongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(name1).NotTo(Equal(name2))
+		})
+
+		It("should return deterministic names", func() {
+			name := util.GetValidName("CongaOrg", "CongaOrgPeer0", "fabcar:cffa266294278404e5071cb91150d550dc0bf855149908a170b1169d6160004b")
+			Expect(name).To(Equal("cc-ocqvh9ir0mi0ef6urh12f3l0dar6csdmtjfhgbfvdp2d22u109r0"))
+		})
+	})
+})

--- a/internal/util/util_suite_test.go
+++ b/internal/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}


### PR DESCRIPTION
Generate a valid RFC 1035 label name from an MSP ID, peer ID, and chaincode ID.

Closes #16

Signed-off-by: James Taylor <jamest@uk.ibm.com>