### PR TITLE
Update amd64 Dockerfile from alpine-based to ubuntu-based

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-ARG GO_VER=1.17.5
-ARG ALPINE_VER=3.14
-ARG HLF_VERSION=2.4
+ARG UBUNTU_VER=20.04
+ARG HLF_VERSION=2.5
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as build
-RUN apk add --no-cache \
-	bash \
-	binutils-gold \
-	gcc \
-	git \
-	make \
-	musl-dev
+FROM ubuntu:${UBUNTU_VER} as build
+ARG GO_VER=1.20.3
+ENV GOPATH /go
+
+RUN apt update && apt install -y \
+    git \
+    gcc \
+    curl \
+    make
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.linux-$(dpkg --print-architecture).tar.gz | tar zxf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
 
 ADD . $GOPATH/src/github.com/hyperledger-labs/fabric-builder-k8s
 WORKDIR $GOPATH/src/github.com/hyperledger-labs/fabric-builder-k8s
@@ -18,10 +21,10 @@ RUN go install ./cmd/...
 
 FROM hyperledger/fabric-peer:${HLF_VERSION} as core
 
-RUN apk add --no-cache \
-	wget;
+RUN apt update && apt install -y \
+    wget
 
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linux_$(dpkg --print-architecture) -O /usr/bin/yq && chmod +x /usr/bin/yq
 
 RUN yq 'del(.vm.endpoint) | .chaincode.externalBuilders += { "name": "k8s_builder", "path": "/opt/hyperledger/k8s_builder", "propagateEnvironment": [ "CORE_PEER_ID", "KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT" ] }' ${FABRIC_CFG_PATH}/core.yaml > core.yaml
 


### PR DESCRIPTION
From 2.5.0, Fabric switches base docker images from golang-alpine to ubuntu 20.
This patch follows this update.

Resolves #91 