### PR TITLE
Copy statedb/couchdb recursively discarding non .json files to create index for public and private data assets.

### DIFF
--- a/cmd/release/main_test.go
+++ b/cmd/release/main_test.go
@@ -48,8 +48,16 @@ var _ = Describe("Main", func() {
 
 		indexPath := filepath.Join(tempDir, "statedb", "couchdb", "indexes", "indexOwner.json")
 		Expect(indexPath).To(BeARegularFile())
+
+		assetPrivateDataCollectionIndexPath := filepath.Join(tempDir, "statedb", "couchdb", "collections", "assetCollection", "indexes", "indexOwner.json")
+		Expect(assetPrivateDataCollectionIndexPath).To(BeARegularFile(), "Private data index should be copied")
+
+		fabCarPrivateDataCollectionIndexPath := filepath.Join(tempDir, "statedb", "couchdb", "collections", "fabCarCollection", "indexes", "indexOwner.json")
+		Expect(fabCarPrivateDataCollectionIndexPath).To(BeARegularFile(), "Private data index should be copied")
+
 		textPath := filepath.Join(tempDir, "statedb", "couchdb", "indexes", "test.txt")
-		Expect(textPath).NotTo(BeAnExistingFile())
+		Expect(textPath).NotTo(BeAnExistingFile(), "Unexpected files should not be copied")
+
 		subdirPath := filepath.Join(
 			tempDir,
 			"statedb",
@@ -58,6 +66,18 @@ var _ = Describe("Main", func() {
 			"subdir",
 			"indexOwner.json",
 		)
-		Expect(subdirPath).NotTo(BeAnExistingFile())
+		Expect(subdirPath).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
+
+		privateDataCollectionSubdirPath := filepath.Join(
+			tempDir,
+			"statedb",
+			"couchdb",
+			"collections",
+			"fabCarCollection",
+			"subdir",
+			"indexes",
+			"indexOwner.json",
+		)
+		Expect(privateDataCollectionSubdirPath).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
 	})
 })

--- a/cmd/release/main_test.go
+++ b/cmd/release/main_test.go
@@ -79,5 +79,42 @@ var _ = Describe("Main", func() {
 			"indexOwner.json",
 		)
 		Expect(privateDataCollectionSubdirPath).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
+
+		collectionsdCollectionPath := filepath.Join(
+			tempDir,
+			"statedb",
+			"couchdb",
+			"collectionsd",
+			"fabCarCollection",
+			"indexes",
+			"indexOwner.json",
+		)
+		Expect(collectionsdCollectionPath).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
+
+		indexedCollectionSubdirPath := filepath.Join(
+			tempDir,
+			"statedb",
+			"couchdb",
+			"indexed",
+			"indexes",
+			"indexOwner.json",
+		)
+		Expect(indexedCollectionSubdirPath).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
+
+		rootIndexOwnerJSONFile := filepath.Join(
+			tempDir,
+			"statedb",
+			"couchdb",
+			"indexOwner.json",
+		)
+		Expect(rootIndexOwnerJSONFile).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
+
+		roottestTXTFile := filepath.Join(
+			tempDir,
+			"statedb",
+			"couchdb",
+			"test.txt",
+		)
+		Expect(roottestTXTFile).NotTo(BeAnExistingFile(), "Files outside indexes directory should not be copied")
 	})
 })

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/assetCollection/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/assetCollection/indexes/indexOwner.json
@@ -1,0 +1,11 @@
+{
+    "index": {
+      "fields": [
+        "objectType",
+        "owner"
+      ]
+    },
+    "ddoc": "indexOwnerDoc",
+    "name": "indexOwner",
+    "type": "json"
+}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/fabCarCollection/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/fabCarCollection/indexes/indexOwner.json
@@ -1,0 +1,11 @@
+{
+    "index": {
+      "fields": [
+        "model",
+        "owner"
+      ]
+    },
+    "ddoc": "indexOwnerDoc",
+    "name": "indexOwner",
+    "type": "json"
+}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/fabCarCollection/subdir/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collections/fabCarCollection/subdir/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/assetCollection/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/assetCollection/indexes/indexOwner.json
@@ -1,0 +1,11 @@
+{
+    "index": {
+      "fields": [
+        "objectType",
+        "owner"
+      ]
+    },
+    "ddoc": "indexOwnerDoc",
+    "name": "indexOwner",
+    "type": "json"
+}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/fabCarCollection/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/fabCarCollection/indexes/indexOwner.json
@@ -1,0 +1,11 @@
+{
+    "index": {
+      "fields": [
+        "model",
+        "owner"
+      ]
+    },
+    "ddoc": "indexOwnerDoc",
+    "name": "indexOwner",
+    "type": "json"
+}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/fabCarCollection/subdir/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/collectionsd/fabCarCollection/subdir/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/subdir/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/subdir/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/test.txt
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/indexed/test.txt
@@ -1,0 +1,1 @@
+Testing

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/subdir/indexOwner.json
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/subdir/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/test.txt
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/subdir/indexes/test.txt
@@ -1,0 +1,1 @@
+Testing

--- a/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/test.txt
+++ b/cmd/release/testdata/buildwithindexes/META-INF/statedb/couchdb/test.txt
@@ -1,0 +1,1 @@
+Testing

--- a/internal/builder/release.go
+++ b/internal/builder/release.go
@@ -19,7 +19,7 @@ func (r *Release) Run(ctx context.Context) error {
 	logger.Debugln("Releasing chaincode...")
 
 	// If CouchDB index definitions are required for the chaincode, release is
-	// responsible for placing the indexes into the statedb/couchdb/indexes
+	// responsible for placing the indexes into the statedb/couchdb/
 	// directory under RELEASE_OUTPUT_DIR. The indexes must have a .json
 	// extension.
 	err := util.CopyIndexFiles(logger, r.BuildOutputDirectory, r.ReleaseOutputDirectory)

--- a/internal/util/copy.go
+++ b/internal/util/copy.go
@@ -66,9 +66,9 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 	}
 
 	opt := copy.Options{
-		Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
+		Skip: func(info os.FileInfo, src, _ string) (bool, error) {
 			logger.Debugf("Checking source copy path: %s", src)
-			fileInfo, err := os.Lstat(src)
+
 			if err != nil {
 				return true, fmt.Errorf(
 					"failed to create CouchDB index definitions from folder %s: %w",
@@ -76,18 +76,15 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 					err,
 				)
 			}
-			if fileInfo.IsDir() { // copy it recursively
+
+			if info.IsDir() {
 				logger.Debugf("This is a folder, copying: %s", src)
+
 				return false, nil
-			} else { // any non JSON will be skipped
-				isJsonFile := strings.HasSuffix(src, ".json")
-				if isJsonFile {
-					logger.Debugf("This is a JSON file, copying: %s", src)
-				} else {
-					logger.Debugf("This is NOT a JSON file, skipping copy: %s", src)
-				}
-				return !isJsonFile, nil
 			}
+			logger.Debugf("Checking if it is a JSON file: %s", src)
+
+			return !strings.HasSuffix(src, ".json"), nil
 		},
 	}
 

--- a/internal/util/copy.go
+++ b/internal/util/copy.go
@@ -67,7 +67,7 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 
 	opt := copy.Options{
 		Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
-			logger.Debugf("Source folder to check and skip copy: %s", src)
+			logger.Debugf("Checking source copy path: %s", src)
 			fileInfo, err := os.Lstat(src)
 			if err != nil {
 				return true, fmt.Errorf(
@@ -77,11 +77,16 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 				)
 			}
 			if fileInfo.IsDir() { // copy it recursively
-				logger.Debugf("This is a folder: %s", src)
+				logger.Debugf("This is a folder, copying: %s", src)
 				return false, nil
-			} else { // any file that will not be a JSON will be skipped
-				logger.Debugf("This is a file: %s", src)
-				return !strings.HasSuffix(src, ".json"), nil
+			} else { // any non JSON will be skipped
+				isJsonFile := strings.HasSuffix(src, ".json")
+				if isJsonFile {
+					logger.Debugf("This is a JSON file, copying: %s", src)
+				} else {
+					logger.Debugf("This is NOT a JSON file, skipping copy: %s", src)
+				}
+				return !isJsonFile, nil
 			}
 		},
 	}

--- a/internal/util/copy.go
+++ b/internal/util/copy.go
@@ -41,19 +41,27 @@ func CopyImageJSON(logger *log.CmdLogger, src, dest string) error {
 
 // CopyIndexFiles copies CouchDB index definitions from source to destination directories.
 func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
+	logger.Debugf("Copying couchdb index files from %s to %s", src, dest)
+
+	_, err := os.Lstat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// indexes are optional
+			return nil
+		}
+
+		return err
+	}
+
 	indexDir := filepath.Join("statedb", "couchdb")
 	indexSrcDir := filepath.Join(src, MetadataDir, indexDir)
 	indexDestDir := filepath.Join(dest, indexDir)
 
-	logger.Debugf("Copying CouchDB index definitions from %s to %s", indexSrcDir, indexDestDir)
-
 	opt := copy.Options{
 		Skip: func(info os.FileInfo, src, _ string) (bool, error) {
 			logger.Debugf("Checking source copy path: %s", src)
-
 			if info.IsDir() {
 				skip, err := skipFolder(logger, indexSrcDir, src)
-
 				if err != nil {
 					return skip, fmt.Errorf(
 						"error checking if the folder is eligible to have a couchdb index: %s, %s: %w",
@@ -66,9 +74,17 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 				return skip, nil
 			}
 
-			logger.Debugf("Checking if it is a JSON file: %s", src)
+			skip, err := skipFile(indexSrcDir, src)
+			if err != nil {
+				return skip, fmt.Errorf(
+					"error checking if the file is eligible to have a couchdb index: %s, %s: %w",
+					indexSrcDir,
+					src,
+					err,
+				)
+			}
 
-			return !strings.HasSuffix(src, ".json"), nil
+			return skip, nil
 		},
 	}
 
@@ -82,89 +98,6 @@ func CopyIndexFiles(logger *log.CmdLogger, src, dest string) error {
 	}
 
 	return nil
-}
-
-// skipFolder checks if the folder will need to be skipped during indexes copy.
-func skipFolder(logger *log.CmdLogger, indexSrcDir, src string) (bool, error) {
-	path, err := filepath.Rel(indexSrcDir, src)
-
-	if err != nil {
-		return true, fmt.Errorf(
-			"error resolving the relative path: %s, %s: %w",
-			indexSrcDir,
-			src,
-			err,
-		)
-	}
-
-	matchContainsPublicIndexFolder, err := filepath.Match("indexes", path)
-
-	if err != nil {
-		return true, fmt.Errorf(
-			"error matching the path with public index couchdb folder: %s: %w",
-			path,
-			err,
-		)
-	}
-
-	matchContainsPrivateDataCollectionFolder, err := filepath.Match("collections", path)
-
-	if err != nil {
-		return true, fmt.Errorf(
-			"error matching the path with the collection folder: %s: %w",
-			path,
-			err,
-		)
-	}
-
-	matchPrivateDataCollectionFolder, err := filepath.Match("collections/*", path)
-
-	if err != nil {
-		return true, fmt.Errorf(
-			"error matching the path with the private data collection definition folder: %s: %w",
-			path,
-			err,
-		)
-	}
-
-	matchPrivateDataCollectionIndexFolder, err := filepath.Match("collections/*/indexes", path)
-
-	if err != nil {
-		return true, fmt.Errorf(
-			"error matching the path with the private data collection index definition folder: %s: %w",
-			path,
-			err,
-		)
-	}
-	relativeFoldersLength := len(strings.Split(path, string(filepath.Separator)))
-
-	logger.Debugf("relative path: %s, total relative folders: %d", path, relativeFoldersLength)
-	logger.Debugf("Match pattern - index: %t", matchContainsPublicIndexFolder)
-	logger.Debugf("Match pattern - collections: %t", matchContainsPrivateDataCollectionFolder)
-	logger.Debugf("Match pattern - collections/*: %t", matchPrivateDataCollectionFolder)
-	logger.Debugf("Match pattern - collections/*/indexes: %t", matchPrivateDataCollectionIndexFolder)
-
-	switch {
-	case relativeFoldersLength == 1 && (!matchContainsPublicIndexFolder && !matchContainsPrivateDataCollectionFolder):
-		logger.Debugf("Should skip folder")
-
-		return true, nil
-
-	case relativeFoldersLength == 2 && (!matchPrivateDataCollectionFolder):
-		logger.Debugf("Should skip folder")
-
-		return true, nil
-
-	case relativeFoldersLength == 3 && (!matchPrivateDataCollectionIndexFolder):
-		logger.Debugf("Should skip folder")
-
-		return true, nil
-
-	default:
-		logger.Debugf("Should NOT skip folder")
-
-		return false, nil
-	}
 }
 
 // CopyMetadataDir copies all chaincode metadata from source to destination directories.
@@ -198,4 +131,66 @@ func CopyMetadataDir(logger *log.CmdLogger, src, dest string) error {
 	}
 
 	return nil
+}
+
+func skipFile(indexSrcDir, src string) (bool, error) {
+	path, err := filepath.Rel(indexSrcDir, src)
+	if err != nil {
+		return true, fmt.Errorf(
+			"error verifying relative path from %s to %s: %w",
+			indexSrcDir,
+			src,
+			err,
+		)
+	}
+
+	if len(strings.Split(path, string(filepath.Separator))) == 1 { // JSON is in root couchdb folder
+		return true, nil
+	}
+
+	return !strings.HasSuffix(src, ".json"), nil
+}
+
+// skipFolder checks if the folder will need to be skipped during indexes copy.
+func skipFolder(logger *log.CmdLogger, indexSrcDir, src string) (bool, error) {
+	path, err := filepath.Rel(indexSrcDir, src)
+	if err != nil {
+		logger.Debugf("failed resolve relative path: %s, src: %s", indexSrcDir, src)
+
+		return true, fmt.Errorf("failed resolve relative path %s to %s: %w", indexSrcDir, src, err)
+	}
+
+	matchContainsPublicIndexFolder, _ := filepath.Match("indexes", path)
+	matchContainsPrivateDataCollectionFolder, _ := filepath.Match("collections", path)
+	matchPrivateDataCollectionFolder, _ := filepath.Match("collections/*", path)
+	matchPrivateDataCollectionIndexFolder, _ := filepath.Match("collections/*/indexes", path)
+	relativeFoldersLength := len(strings.Split(path, string(filepath.Separator)))
+
+	logger.Debugf("Calculated relative path: %s. Total relative folders: %d", path, relativeFoldersLength)
+	logger.Debugf("Match pattern 'index': %t", matchContainsPublicIndexFolder)
+	logger.Debugf("Match pattern 'collections': %t", matchContainsPrivateDataCollectionFolder)
+	logger.Debugf("Match pattern 'collections/*': %t", matchPrivateDataCollectionFolder)
+	logger.Debugf("Match pattern 'collections/*/indexes': %t", matchPrivateDataCollectionIndexFolder)
+
+	switch {
+	case relativeFoldersLength == 1 && (!matchContainsPublicIndexFolder && !matchContainsPrivateDataCollectionFolder):
+		logger.Debugf("Should skip folder")
+
+		return true, nil
+
+	case relativeFoldersLength == 2 && (!matchPrivateDataCollectionFolder):
+		logger.Debugf("Should skip folder")
+
+		return true, nil
+
+	case relativeFoldersLength == 3 && (!matchPrivateDataCollectionIndexFolder):
+		logger.Debugf("Should skip folder")
+
+		return true, nil
+
+	default:
+		logger.Debugf("Should not skip folder")
+
+		return false, nil
+	}
 }


### PR DESCRIPTION
Related to issue: #106 

Problem when private data indexing is needed.