### PR TITLE
Update docker build permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pushing to ghcr has started failing with 403 Forbidden Hopefully this will fix it although there may also be some org permissions to update