### PR TITLE
Add xxd to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/go:1-1.23-bookworm
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends \
+  xxd

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Fabric k8s builder",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+
+	// Use a Dockerfile. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {


### PR DESCRIPTION
The xxd command can be used to encode chaincode package hashes, as used by the k8s builder to label chaincode jobs and pods

For example:

```
peer lifecycle chaincode calculatepackageid go-contract.tgz | cut -d':' -f2 | xxd -r -p | base32 | tr -d '='
```